### PR TITLE
Fix changelog race in Mondrinth/CurseForge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -712,7 +712,8 @@ idea {
 
 
 // Deployment
-
+def final modrinthApiKey = providers.environmentVariable('MODRINTH_API_KEY')
+def final cfApiKey = providers.environmentVariable('CURSEFORGE_API_KEY')
 final boolean isCIEnv = providers.environmentVariable('CI').getOrElse('false').toBoolean()
 
 if (isCIEnv || deploymentDebug.toBoolean()) {
@@ -749,58 +750,62 @@ tasks.register('generateChangelog') {
             changelog = "Changes since ${lastTag}:\n${{("\n" + changelog).replaceAll("\n", "\n* ")}}"
         }
         def f = getFile('build/changelog.md')
-        f.write(changelog ?: 'There have been no changes.', 'UTF-8')
+        changelog = changelog ?: 'There have been no changes.'
+        f.write(changelog, 'UTF-8')
+
+        // Set changelog for Modrinth
+        if (modrinthApiKey.isPresent() || deploymentDebug.toBoolean()) {
+            modrinth.changelog.set(changelog)
+        }
     }
 }
 
-// Curseforge
-def final cfApiKey = providers.environmentVariable('CURSEFORGE_API_KEY')
 if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
     apply plugin: 'net.darkhax.curseforgegradle'
     //noinspection UnnecessaryQualifiedReference
     tasks.register('curseforge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
-        apiToken = cfApiKey.getOrElse('debug_token')
+        doFirst {
+            apiToken = cfApiKey.getOrElse('debug_token')
 
-        def mainFile = upload(curseForgeProjectId, reobfJar)
-        def changelogFile = getChangelog()
-        def changelogRaw = changelogFile.exists() ? changelogFile.getText('UTF-8') : ""
+            def mainFile = upload(curseForgeProjectId, reobfJar)
+            def changelogFile = getChangelog()
+            def changelogRaw = changelogFile.exists() ? changelogFile.getText('UTF-8') : ""
 
-        mainFile.displayName = "${modName}: ${modVersion}"
-        mainFile.releaseType = getReleaseType()
-        mainFile.changelog = changelogRaw
-        mainFile.changelogType = 'markdown'
-        mainFile.addModLoader 'Forge'
-        mainFile.addJavaVersion "Java 8"
-        mainFile.addGameVersion minecraftVersion
+            mainFile.displayName = "${modName}: ${modVersion}"
+            mainFile.releaseType = getReleaseType()
+            mainFile.changelog = changelogRaw
+            mainFile.changelogType = 'markdown'
+            mainFile.addModLoader 'Forge'
+            mainFile.addJavaVersion "Java 8"
+            mainFile.addGameVersion minecraftVersion
 
-        if (curseForgeRelations.size() != 0) {
-            String[] deps = curseForgeRelations.split(';')
-            deps.each { dep ->
-                if (dep.size() == 0) {
-                    return
+            if (curseForgeRelations.size() != 0) {
+                String[] deps = curseForgeRelations.split(';')
+                deps.each { dep ->
+                    if (dep.size() == 0) {
+                        return
+                    }
+                    String[] parts = dep.split(':')
+                    String type = parts[0], slug = parts[1]
+                    if (!(type in ['requiredDependency', 'embeddedLibrary', 'optionalDependency', 'tool', 'incompatible'])) {
+                        throw new Exception('Invalid Curseforge dependency type: ' + type)
+                    }
+                    mainFile.addRelation(slug, type)
                 }
-                String[] parts = dep.split(':')
-                String type = parts[0], slug = parts[1]
-                if(!(type in ['requiredDependency', 'embeddedLibrary', 'optionalDependency', 'tool', 'incompatible'])) {
-                    throw new Exception('Invalid Curseforge dependency type: ' + type)
-                }
-                mainFile.addRelation(slug, type)
             }
-        }
 
-        for (artifact in getSecondaryArtifacts()) {
-            def additionalFile = mainFile.withAdditionalFile(artifact)
-            additionalFile.changelog = changelogRaw
+            for (artifact in getSecondaryArtifacts()) {
+                def additionalFile = mainFile.withAdditionalFile(artifact)
+                additionalFile.changelog = changelogRaw
+            }
+            disableVersionDetection()
+            debugMode = deploymentDebug.toBoolean()
         }
-        disableVersionDetection()
-        debugMode = deploymentDebug.toBoolean()
     }
     tasks.curseforge.dependsOn(build)
     tasks.curseforge.dependsOn('generateChangelog')
 }
 
-// Modrinth
-def final modrinthApiKey = providers.environmentVariable('MODRINTH_API_KEY')
 if (modrinthApiKey.isPresent() || deploymentDebug.toBoolean()) {
     apply plugin: 'com.modrinth.minotaur'
     def final changelogFile = getChangelog()

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
     id 'com.gtnewhorizons.retrofuturagradle' version '1.3.19'
-    id 'net.darkhax.curseforgegradle' version '1.0.7' apply false
+    id 'net.darkhax.curseforgegradle' version '1.0.14' apply false
     id 'com.modrinth.minotaur' version '2.8.0' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
     id 'com.palantir.git-version' version '3.0.0' apply false
@@ -764,9 +764,11 @@ if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
     apply plugin: 'net.darkhax.curseforgegradle'
     //noinspection UnnecessaryQualifiedReference
     tasks.register('curseforge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
-        doFirst {
-            apiToken = cfApiKey.getOrElse('debug_token')
+        disableVersionDetection()
+        debugMode = deploymentDebug.toBoolean()
+        apiToken = cfApiKey.getOrElse('debug_token')
 
+        doFirst {
             def mainFile = upload(curseForgeProjectId, reobfJar)
             def changelogFile = getChangelog()
             def changelogRaw = changelogFile.exists() ? changelogFile.getText('UTF-8') : ""
@@ -798,8 +800,6 @@ if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
                 def additionalFile = mainFile.withAdditionalFile(artifact)
                 additionalFile.changelog = changelogRaw
             }
-            disableVersionDetection()
-            debugMode = deploymentDebug.toBoolean()
         }
     }
     tasks.curseforge.dependsOn(build)


### PR DESCRIPTION
Moves the CurseForge logic to `doFirst` so it runs after the task dependencies instead of the config body.
Allows Modrinth to still look for changelog files, but makes the `generateChangelog` task forcefully update the changelog.