### PR TITLE
Update MixinBooter version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -401,8 +401,8 @@ configurations {
 
 dependencies {
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation 'zone.rong:mixinbooter:7.0'
-        String mixin = 'org.spongepowered:mixin:0.8.3'
+        implementation 'zone.rong:mixinbooter:8.3'
+        String mixin = 'zone.rong:mixinbooter:8.3'
         if (usesMixins.toBoolean()) {
             mixin = modUtils.enableMixins(mixin, "mixins.${modId}.refmap.json")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -368,10 +368,6 @@ repositories {
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        maven {
-            name 'Sponge Maven'
-            url 'https://repo.spongepowered.org/maven'
-        }
         // need to add this here even if we did not above
         if (!includeWellKnownRepositories.toBoolean()) {
             maven {


### PR DESCRIPTION
Updates MixinBooter to 8.3.

Pulls Mixins from MixinBooter to take advantage of them now using UniMix, which is an up to date mixin fork (which fixes some issues in CEu that we have seen)