### PR TITLE
Separate client/server run directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnset("usesShadowedDependencies", false)
 propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 propertyDefaultIfUnset("relocateShadowedDependencies", true)
+propertyDefaultIfUnset("separateRunDirectories", false)
 propertyDefaultIfUnsetWithEnvVar("modrinthProjectId", "", "MODRINTH_PROJECT_ID")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnsetWithEnvVar("curseForgeProjectId", "", "CURSEFORGE_PROJECT_ID")
@@ -590,12 +591,14 @@ jar {
 }
 
 // Configure default run tasks
-runClient {
-    workingDir = file('run/client')
-}
+if (separateRunDirectories.toBoolean()) {
+    runClient {
+        workingDir = file('run/client')
+    }
 
-runServer {
-    workingDir = file('run/server')
+    runServer {
+        workingDir = file('run/server')
+    }
 }
 
 // Create API library jar

--- a/build.gradle
+++ b/build.gradle
@@ -589,6 +589,15 @@ jar {
     }
 }
 
+// Configure default run tasks
+runClient {
+    workingDir = file('run/client')
+}
+
+runServer {
+    workingDir = file('run/server')
+}
+
 // Create API library jar
 tasks.register('apiJar', Jar) {
     archiveClassifier.set 'api'

--- a/gradle.properties
+++ b/gradle.properties
@@ -80,6 +80,10 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
+# Separate run directories into "run/client" for runClient task, and "run/server" for runServer task.
+# Useful for debugging a server and client simultaneously. If not enabled, it will be in the standard location "run/"
+separateRunDirectories = false
+
 
 # Publishing to modrinth requires you to set the MODRINTH_API_KEY environment variable to your current modrinth API token.
 


### PR DESCRIPTION
Allows debugging both the client and dedicated server simultaneously without shoving their files into the same directory.