### PR TITLE
Add Option for generating mixin config json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
 propertyDefaultIfUnset("noPublishedSources", false)
 propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("generateMixinConfig", true)
 propertyDefaultIfUnset("usesShadowedDependencies", false)
 propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 propertyDefaultIfUnset("relocateShadowedDependencies", true)
@@ -561,7 +562,7 @@ tasks.register('generateAssets') {
         }
 
         // mixins.{modid}.json
-        if (usesMixins.toBoolean()) {
+        if (usesMixins.toBoolean() && generateMixinConfig.toBoolean()) {
             def mixinConfigFile = getFile("src/main/resources/mixins.${modId}.json")
             if (!mixinConfigFile.exists()) {
                 def mixinConfigRefmap = "mixins.${modId}.refmap.json"

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,6 +52,8 @@ accessTransformersFile =
 usesMixins = false
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
 mixinsPackage =
+# Automatically generates a mixin config json if enabled, with the name mixins.modid.json
+generateMixinConfig = true
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
 # Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
 coreModClass =


### PR DESCRIPTION
Adds an option for generating the mixin config json. Some mods may break up this file into different files, such as mixin configs per mod that they are targeting. Therefore, they might not want this file auto generated all the time if they are not using it.