### PR TITLE
Coremod improvements, debugging, obf task fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style
 plugins {
     id 'java'
     id 'java-library'
+    id 'base'
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
@@ -277,7 +278,10 @@ else {
 }
 
 group = modGroup
-archivesBaseName = modArchivesBaseName
+
+base {
+    archivesName = modArchivesBaseName
+}
 
 minecraft {
     mcVersion = minecraftVersion

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.22'
     id 'net.darkhax.curseforgegradle' version '1.0.14' apply false
     id 'com.modrinth.minotaur' version '2.8.0' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -432,6 +432,7 @@ dependencies {
     }
 
     if (enableJUnit.toBoolean()) {
+        testImplementation 'org.hamcrest:hamcrest:2.2'
         testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -411,13 +411,15 @@ configurations {
 }
 
 dependencies {
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation 'zone.rong:mixinbooter:8.3'
-        String mixin = 'zone.rong:mixinbooter:8.3'
-        if (usesMixins.toBoolean()) {
-            mixin = modUtils.enableMixins(mixin, "mixins.${modId}.refmap.json")
-        }
+    String mixin = 'zone.rong:mixinbooter:8.3'
+    if (usesMixins.toBoolean()) {
+        annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
+        // should use 24.1.1 but 30.0+ has a vulnerability fix
+        annotationProcessor 'com.google.guava:guava:30.0-jre'
+        // should use 2.8.6 but 2.8.9+ has a vulnerability fix
+        annotationProcessor 'com.google.code.gson:gson:2.8.9'
 
+        mixin = modUtils.enableMixins(mixin, "mixins.${modId}.refmap.json")
         api (mixin) {
             transitive = false
         }
@@ -425,17 +427,13 @@ dependencies {
         annotationProcessor(mixin) {
             transitive = false
         }
-
-        annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
-        // should use 24.1.1 but 30.0+ has a vulnerability fix
-        annotationProcessor 'com.google.guava:guava:30.0-jre'
-        // should use 2.8.6 but 2.8.9+ has a vulnerability fix
-        annotationProcessor 'com.google.code.gson:gson:2.8.9'
+    } else if (forceEnableMixins.toBoolean()) {
+        runtimeOnly(mixin)
     }
 
     if (enableJUnit.toBoolean()) {
-        testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
-        testImplementation 'org.hamcrest:hamcrest:2.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }
 
     if (enableModernJavaSyntax.toBoolean()) {

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
 propertyDefaultIfUnset("noPublishedSources", false)
 propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnsetWithEnvVar("enableCoreModDebug", false, "CORE_MOD_DEBUG")
 propertyDefaultIfUnset("generateMixinConfig", true)
 propertyDefaultIfUnset("usesShadowedDependencies", false)
 propertyDefaultIfUnset("minimizeShadowedDependencies", true)
@@ -308,6 +309,14 @@ minecraft {
             '-Dmixin.debug.export=true'
         ])
     }
+
+    if (enableCoreModDebug.toBoolean()) {
+        extraRunJvmArguments.addAll([
+                '-Dlegacy.debugClassLoading=true',
+                '-Dlegacy.debugClassLoadingFiner=true',
+                '-Dlegacy.debugClassLoadingSave=true'
+        ])
+    }
 }
 
 if (coreModClass) {
@@ -380,6 +389,11 @@ repositories {
         maven {
             name 'BlameJared Maven'
             url 'https://maven.blamejared.com'
+        }
+        maven {
+            name 'GTNH Maven'
+            url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public'
+            allowInsecureProtocol = true
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
@@ -457,6 +471,9 @@ dependencies {
 
     compileOnlyApi 'org.jetbrains:annotations:23.0.0'
     annotationProcessor 'org.jetbrains:annotations:23.0.0'
+    patchedMinecraft('net.minecraft:launchwrapper:1.15') {
+        transitive = false
+    }
 
     if (includeCommonDevEnvMods.toBoolean()) {
         implementation 'mezz.jei:jei_1.12.2:4.16.1.302'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.22'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.23'
     id 'net.darkhax.curseforgegradle' version '1.0.14' apply false
     id 'com.modrinth.minotaur' version '2.8.0' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -308,8 +308,13 @@ minecraft {
             '-Dmixin.debug.export=true'
         ])
     }
-    if (coreModClass) {
-        extraRunJvmArguments.add("-Dfml.coreMods.load=${modGroup}.${coreModClass}")
+}
+
+if (coreModClass) {
+    for (runTask in ['runClient', 'runServer']) {
+        tasks.named(runTask).configure {
+            extraJvmArgs.add("-Dfml.coreMods.load=${modGroup}.${coreModClass}")
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -64,6 +64,11 @@ containsMixinsAndOrCoreModOnly = false
 # Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
 forceEnableMixins = false
 
+# Outputs pre-transformed and post-transformed loaded classes to run/CLASSLOADER_TEMP. Can be used in combination with
+# diff to see exactly what your ASM or Mixins are changing in the target file.
+# Optionally can be specified with the 'CORE_MOD_DEBUG' env var. Will output a lot of files!
+enableCoreModDebug = false
+
 # Adds CurseMaven, Modrinth Maven, BlameJared maven, and some more well-known 1.12.2 repositories
 includeWellKnownRepositories = true
 


### PR DESCRIPTION
- Fix `runObfClient`/`runObfServer` crash with `fml.coreMods.load` cli arg passed unnecessarily
- Fix `runObfServer` crash with pointing to 1.7.10's ServerLaunch class instead of 1.12.2's (fixed in https://github.com/GTNewHorizons/RetroFuturaGradle/pull/42, released in RFG 1.3.22)
- Move to updated LegacyLauncher for better logging and coremod debug
- Add prompt for online-mode for first run of `runServer` (added in https://github.com/GTNewHorizons/RetroFuturaGradle/pull/43, released in RFG 1.3.23)
- Remove mixin and its transitive deps from compile classpath if only `forceEnableMixins` is enabled (and not `usesMixins`)
- Fix deprecation warnings

### Main feature:
- Add `enableCoreModDebug` option (with env var substitute `CORE_MOD_DEBUG`)
  - When enabled, outputs loaded classes to `run/CLASSLOADER_TEMP`
  - Outputs `pretransform` raw class and all transformed classes. Usually this just is MCP transformer, but will also have separate output classes for each Mixin or ASM transformer targeting a class
  - Allows for easy diffing between different transformation points to see exactly how your Mixin or ASM affected a class