### PR TITLE
Update MixinBooter version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -456,7 +456,7 @@ configurations {
     }
 }
 
-String mixinProviderSpec = 'zone.rong:mixinbooter:8.3'
+String mixinProviderSpec = 'zone.rong:mixinbooter:8.9'
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'


### PR DESCRIPTION
Updates Mixinbooter versions, so that we can take advantage of the newer MixinExtras, which is shadowed by Mixinbooter