### PR TITLE
Better maven info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1012,7 +1012,7 @@ def getSecondaryArtifacts() {
 }
 
 def getReleaseType() {
-    String type = providers.environmentVariable('RELEASE_TYPE').getOrElse(project.releaseType)
+    String type = project.releaseType
     if (!(type in ['release', 'beta', 'alpha'])) {
         throw new Exception("Release type invalid! Found \"" + type + "\", allowed: \"release\", \"beta\", \"alpha\"")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1011,7 +1011,7 @@ def getSecondaryArtifacts() {
 }
 
 def getReleaseType() {
-    String type = project.releaseType
+    String type = providers.environmentVariable('RELEASE_TYPE').getOrElse(project.releaseType)
     if (!(type in ['release', 'beta', 'alpha'])) {
         throw new Exception("Release type invalid! Found \"" + type + "\", allowed: \"release\", \"beta\", \"alpha\"")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ propertyDefaultIfUnset("curseForgeRelations", "")
 propertyDefaultIfUnsetWithEnvVar("releaseType", "release", "RELEASE_TYPE")
 propertyDefaultIfUnset("generateDefaultChangelog", false)
 propertyDefaultIfUnset("customMavenPublishUrl", "")
+propertyDefaultIfUnset("mavenArtifactGroup", getDefaultArtifactGroup())
 propertyDefaultIfUnset("enableModernJavaSyntax", false)
 propertyDefaultIfUnset("enableSpotless", false)
 propertyDefaultIfUnset("enableJUnit", false)
@@ -984,8 +985,8 @@ if (customMavenPublishUrl) {
                 }
 
                 // providers is not available here, use System for getting env vars
-                groupId = System.getenv('ARTIFACT_GROUP_ID') ?: project.group
-                artifactId = System.getenv('ARTIFACT_ID') ?: project.name
+                groupId = System.getenv('ARTIFACT_GROUP_ID') ?: project.mavenArtifactGroup
+                artifactId = System.getenv('ARTIFACT_ID') ?: project.modArchivesBaseName
                 version = System.getenv('RELEASE_VERSION') ?: publishedVersion
             }
         }
@@ -1129,6 +1130,11 @@ tasks.register('faq') {
 
 
 // Helpers
+
+def getDefaultArtifactGroup() {
+    def lastIndex = project.modGroup.lastIndexOf('.')
+    return lastIndex < 0 ? project.modGroup : project.modGroup.substring(0, lastIndex)
+}
 
 def getFile(String relativePath) {
     return new File(projectDir, relativePath)

--- a/gradle.properties
+++ b/gradle.properties
@@ -145,7 +145,7 @@ noPublishedSources = false
 customMavenPublishUrl =
 
 # The group for maven artifacts. Defaults to the 'project.modGroup' until the last '.' (if any).
-# So 'mymod' becomes 'mymoc' and 'com.myname.mymodid' 'becomes com.myname'
+# So 'mymod' becomes 'mymod' and 'com.myname.mymodid' 'becomes com.myname'
 mavenArtifactGroup =
 
 # Enable spotless checks

--- a/gradle.properties
+++ b/gradle.properties
@@ -144,6 +144,10 @@ noPublishedSources = false
 # Password is set with the 'MAVEN_PASSWORD' environment variable, default to "NONE"
 customMavenPublishUrl =
 
+# The group for maven artifacts. Defaults to the 'project.modGroup' until the last '.' (if any).
+# So 'mymod' becomes 'mymoc' and 'com.myname.mymodid' 'becomes com.myname'
+mavenArtifactGroup =
+
 # Enable spotless checks
 # Enforces code formatting on your source code
 # By default this will use the files found here: https://github.com/GregTechCEu/Buildscripts/tree/master/spotless


### PR DESCRIPTION
Before the maven group was the mod group which in my case would be `com.cleanroommc.modularui`, but i need to only be `com.cleanroommc`. So i made a new property which defaults to the mod group until the last '.'.

The maven artifact name was the project name, which is weird. I changed it to the `modArchivesBaseName` property. However i would prefer if it had its own property.