### PR TITLE
Parse relations from json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -904,7 +904,7 @@ if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
             mainFile.addJavaVersion "Java 8"
             mainFile.addGameVersion minecraftVersion
 
-            parseRelations(modrinthRelations, Plattform.CURSE).each {
+            parseRelations(curseForgeRelations, Plattform.CURSE).each {
                 mainFile.addRelation(it[1], it[0])
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
 import com.modrinth.minotaur.dependencies.ModDependency
 import com.modrinth.minotaur.dependencies.VersionDependency
+import groovy.json.JsonSlurper
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.internal.logging.text.StyledTextOutputFactory
@@ -62,6 +63,7 @@ propertyDefaultIfUnset("generateGradleTokenClass", "")
 propertyDefaultIfUnset("gradleTokenModId", "")
 propertyDefaultIfUnset("gradleTokenModName", "")
 propertyDefaultIfUnset("gradleTokenVersion", "")
+propertyDefaultIfUnset("gradleTokenDependencies", "")
 propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
 propertyDefaultIfUnset("noPublishedSources", false)
@@ -73,10 +75,11 @@ propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 propertyDefaultIfUnset("relocateShadowedDependencies", true)
 propertyDefaultIfUnset("separateRunDirectories", false)
 propertyDefaultIfUnset("versionDisplayFormat", '$MOD_NAME \u2212 $VERSION')
+propertyDefaultIfUnset("forgeRelations", "relations.json")
 propertyDefaultIfUnsetWithEnvVar("modrinthProjectId", "", "MODRINTH_PROJECT_ID")
-propertyDefaultIfUnset("modrinthRelations", "")
+propertyDefaultIfUnset("modrinthRelations", "relations.json")
 propertyDefaultIfUnsetWithEnvVar("curseForgeProjectId", "", "CURSEFORGE_PROJECT_ID")
-propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("curseForgeRelations", "relations.json")
 propertyDefaultIfUnsetWithEnvVar("releaseType", "release", "RELEASE_TYPE")
 propertyDefaultIfUnset("generateDefaultChangelog", false)
 propertyDefaultIfUnset("customMavenPublishUrl", "")
@@ -342,6 +345,9 @@ minecraft {
     }
     if (gradleTokenVersion) {
         injectedTags.put gradleTokenVersion, modVersion
+    }
+    if (gradleTokenDependencies) {
+        injectedTags.put gradleTokenDependencies, parseForgeDependencies()
     }
 
     // JVM arguments
@@ -898,19 +904,8 @@ if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
             mainFile.addJavaVersion "Java 8"
             mainFile.addGameVersion minecraftVersion
 
-            if (curseForgeRelations.size() != 0) {
-                String[] deps = curseForgeRelations.split(';')
-                deps.each { dep ->
-                    if (dep.size() == 0) {
-                        return
-                    }
-                    String[] parts = dep.split(':')
-                    String type = parts[0], slug = parts[1]
-                    if (!(type in ['requiredDependency', 'embeddedLibrary', 'optionalDependency', 'tool', 'incompatible'])) {
-                        throw new Exception('Invalid Curseforge dependency type: ' + type)
-                    }
-                    mainFile.addRelation(slug, type)
-                }
+            parseRelations(modrinthRelations, Plattform.CURSE).each {
+                mainFile.addRelation(it[1], it[0])
             }
 
             for (artifact in getSecondaryArtifacts()) {
@@ -939,38 +934,150 @@ if (modrinthApiKey.isPresent() || deploymentDebug.toBoolean()) {
         debugMode = deploymentDebug.toBoolean()
         uploadFile = reobfJar
         additionalFiles = getSecondaryArtifacts()
-    }
-    if (modrinthRelations.size() != 0) {
-        String[] deps = modrinthRelations.split(';')
-        deps.each { dep ->
-            if (dep.size() == 0) {
-                return
-            }
-            String[] parts = dep.split(':')
-            String[] qual = parts[0].split('-')
-            addModrinthDep(qual[0], qual[1], parts[1])
-        }
+        dependencies = parseRelations(modrinthRelations, Plattform.MODRINTH)
     }
     tasks.modrinth.dependsOn(build)
     tasks.modrinth.dependsOn('generateChangelog')
 }
 
-def addModrinthDep(String scope, String type, String name) {
-    com.modrinth.minotaur.dependencies.Dependency dep
-    if (!(scope in ['required', 'optional', 'incompatible', 'embedded'])) {
-        throw new Exception('Invalid modrinth dependency scope: ' + scope)
+def parseForgeDependencies() {
+    def deps = ""
+    parseRelations(forgeRelations, Plattform.FORGE).each { List<String> it ->
+        deps += "${it[0]}:${it[1]}"
+        if (!it[2].isEmpty()) deps += "@${it[2]}"
+        deps += ";"
     }
-    switch (type) {
-        case 'project':
-            dep = new ModDependency(name, scope)
-            break
-        case 'version':
-            dep = new VersionDependency(name, scope)
-            break
-        default:
-            throw new Exception('Invalid modrinth dependency type: ' + type)
+    return deps
+}
+
+def parseRelations(String relations, Plattform ctx) {
+    if (relations.isEmpty()) return []
+    def file = getFile(relations)
+    if (!file.exists()) {
+        if (ctx == Plattform.FORGE) return []
+        return parseRelationLegacy(relations, ctx)
     }
-    project.modrinth.dependencies.add(dep)
+    def parsed = []
+    def cfg = new JsonSlurper().parse(file)
+    println cfg
+    parsed.addAll(parseRelationList(cfg, ctx, RelationType.REQUIRED))
+    parsed.addAll(parseRelationList(cfg, ctx, RelationType.OPTIONAL))
+    parsed.addAll(parseRelationList(cfg, ctx, RelationType.EMBEDDED))
+    parsed.addAll(parseRelationList(cfg, ctx, RelationType.INCOMPATIBLE))
+    if (ctx != Plattform.MODRINTH) {
+        parsed.addAll(parseRelationList(cfg, ctx, RelationType.TOOL))
+    }
+    return parsed
+}
+
+static parseRelationLegacy(String relations, Plattform ctx) {
+    def parsed = []
+    relations.split(";").each {
+        if (it.length() == 0) return
+        String[] parts = it.split(':')
+        switch (ctx) {
+            case Plattform.CURSE:
+                String type = parts[0], slug = parts[1]
+                if (!RelationType.values().any { it.cf == type }) {
+                    throw new Exception('Invalid Curseforge dependency type: ' + type)
+                }
+                parsed << [type, slug, '']
+                break
+            case Plattform.MODRINTH:
+                String[] qual = parts[0].split('-')
+                if (!RelationType.values().any { it.mr == qual[0] }) {
+                    throw new Exception('Invalid modrinth dependency scope: ' + qual[0])
+                }
+                def dep
+                switch (qual[1]) {
+                    case 'project':
+                        dep = new ModDependency(parts[1], qual[0])
+                        break
+                    case 'version':
+                        dep = new VersionDependency(parts[1], qual[0])
+                        break
+                    default:
+                        throw new Exception('Invalid modrinth dependency type: ' + type)
+                }
+                parsed << dep
+        }
+    }
+    return parsed
+}
+
+static List<List<String>> parseRelationList(def cfg, Plattform ctx, RelationType type) {
+    def parsed = []
+    for (def dep : type.get(cfg)) {
+        if (dep instanceof String) {
+            if (dep.isEmpty() || dep.startsWith("_comment")) continue
+            def parts = dep.split(";")
+            def order = parts.length == 1 ? 'none' : parts[0].toLowerCase()
+            parts = (parts.length == 1 ? parts[0] : parts[1]).split("@")
+            def version = parts.length == 1 ? '' : parseVersion(parts[1], ctx)
+            def ids = parts[0].split(":")
+            def modId = ids[0]
+            switch (ctx) {
+                case Plattform.FORGE:
+                    if (order == "none") continue
+                    if (type == RelationType.REQUIRED && !("required" in order)) {
+                        order = order.isEmpty() ? "required" : "required-" + order
+                    } else if (order.isEmpty()) {
+                        order = "after"
+                    }
+                    parsed << [order, modId, version]
+                    break
+
+                case Plattform.CURSE:
+                    def id = ids.length > 1 ? ids[1].trim() : modId
+                    if (!id.isEmpty()) parsed << [type.cf, id, version]
+                    break
+                case Plattform.MODRINTH:
+                    def id = ids.length > 2 ? ids[2].trim() : (ids.length > 1 ? ids[1].trim() : modId)
+                    if (!id.isEmpty()) {
+                        parts = id.split("/", 2)
+                        if (parts.length == 1) parsed << new ModDependency(id, type.mr)
+                        else {
+                            id = parts[0]
+                            if (id.isEmpty()) parsed << new VersionDependency(parts[1], type.mr)
+                            else parsed << new VersionDependency(id, parts[1], type.mr)
+                        }
+                    }
+                    break
+            }
+        }
+    }
+    return parsed
+}
+
+static parseVersion(String version, Plattform ctx) {
+    if (version.charAt(0) in ['[' as char, '(' as char]) {
+        if (ctx == Plattform.FORGE) return version
+        return version.substring(1, version.indexOf(','))
+    }
+    if (ctx == Plattform.FORGE) return "[$version,)"
+    return version
+}
+
+enum Plattform {
+    FORGE, CURSE, MODRINTH
+}
+
+enum RelationType {
+    REQUIRED("requiredDependency", "required"),
+    OPTIONAL("optionalDependency", "optional"),
+    EMBEDDED("embeddedLibrary", "embedded"),
+    INCOMPATIBLE("incompatible", "incompatible"),
+    TOOL("tool", "")
+    final String cf, mr
+
+    RelationType(String cf, String mr) {
+        this.cf = cf
+        this.mr = mr
+    }
+
+    def get(def map) {
+        return map[cf] ?: map[mr] ?: Collections.emptyList()
+    }
 }
 
 if (customMavenPublishUrl) {

--- a/docs/relations.md
+++ b/docs/relations.md
@@ -1,0 +1,83 @@
+# Relations
+You can declare Modrinth and Curse relations via the properties in `gradle.properties`.
+However, with more than 3 dependencies that gets really messy.
+
+## Json File
+To solve that problem you can declare your dependencies in a relations json file. With that you can parse Forge, Curse
+and Modrinth dependencies from one file.
+By default, the path is `relations.json`, but it can be configured to anything with the `forgeRelations`, 
+`modrinthRelarions` and `curseForgeRelations` properties.
+That file must be placed in the root folder.
+
+Example:
+````json5
+{
+  // the dependency type
+  // valued values are [required, optional, embedded, incompatible, tool] (tool is Curse only)
+  // the value must be a list with all dependencies of that type
+  "required": [
+    // the base format of a dependency
+    "order;modid:curse-id:modrinth-id/modrinth-version@version"
+  ],
+  "optional": [
+    // the syntax is the same in all types
+    // if other types are empty they can be removed
+  ],
+  "embedded": [
+  ],
+  "incompatible": [
+  ],
+  "tool": [ // Curse only
+  ]
+}
+````
+This explains the structure of the file.
+
+Now let's look at the dependency itself:`"order;modid:curse-id:modrinth-id/modrinth-version@version"`
+
+- `order` is the prefix for forge: `[required]-[after, before]-[client, server]`.
+  The values must be seperated with `-`. `required` is automatically added if the type is `required`.
+  If the string is empty (just a `;`) then `after` is automatically added. If you don't want the dep to be added to
+  you can remove the `order;`.
+- `modid` is the modid for forge. By default, this is also the Curse and Modrinth id.
+- `curse-id` is the Curse slug if the project. Leaving it empty will not add the dep to Curse.
+- `modrinth-id` is the Modrinth slug if the project. Leaving it empty will not add the dep to Modrinth.
+- `modrinth-version` is the optional Modrinth version slug.
+- `@version` is the version range for the forge dependency.
+
+Examples:
+- ````json
+  ";modularui@[2.4.0,)"
+  ````
+  Adds ModularUI dep to Forge, Curse and Modrinth with a Forge version range of 2.4.0 to any
+
+- ````json
+  "modularui"
+  ````
+  Adds ModularUI dep to Curse and Modrinth with any version.
+
+- ````json
+  ";mixinbooter:mixin-booter:mixinbooter@[8.0,)"
+  ````
+  Adds Mixinbooter dep to Forge (with `modrinth`), Curse (`mixin-booter`) and Modrinth (`mixinbooter`).
+
+- ````json
+  ";modularui::@[2.4.0,)"
+  ````
+  Adds ModularUI dep only to forge (since curse and modrinth id are empty).
+
+- ````json
+  ";modularui:modularui-cf-mr@[2.4.0,)"
+  ````
+  Adds ModularUI dep to Forge (`modularui`), Curse (`modularui-cf-mr`) and Modrinth (`modularui-cf-mr`).
+
+- ````json
+  ";mixinbooter::mixinbooter/8.9@[8.0,)"
+  ````
+  Adds Mixinbooter dep to Forge (with `modrinth`) and Modrinth (`mixinbooter`) with a specific dep on version 8.9.
+
+- ````json
+  ";modularui:modularui:/Q8TApfEv@2.4.1"
+  ````
+  Adds ModularUI dep to forge, Curse (`modularui`) and Modrinth (with the version id of the 2.4.1 file) for only version 2.4.1.
+- 

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,8 @@ generateGradleTokenClass = com.myname.mymodid.Tags
 gradleTokenModId = MODID
 gradleTokenModName = MODNAME
 gradleTokenVersion = VERSION
+# This will parse relations from a relations.json file in the root folder. Does nothing if the file is not found.
+gradleTokenDependencies = DEPENDENCIES
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -91,6 +93,9 @@ relocateShadowedDependencies = true
 # Useful for debugging a server and client simultaneously. If not enabled, it will be in the standard location "run/"
 separateRunDirectories = false
 
+# File location of the relations json file.
+forgeRelations = relations.json
+
 # The display name format of versions published to Curse and Modrinth. $MOD_NAME and $VERSION are available variables.
 # Default: $MOD_NAME \u2212 $VERSION. \u2212 is the minus character which looks much better than the hyphen minus on Curse.
 versionDisplayFormat = $MOD_NAME \u2212 $VERSION
@@ -102,13 +107,13 @@ versionDisplayFormat = $MOD_NAME \u2212 $VERSION
 # Alternatively this can be set with the 'MODRINTH_PROJECT_ID' environment variable.
 modrinthProjectId =
 
-# The project's relations on Modrinth. You can use this to refer to other projects on Modrinth.
+# The project's relations on Modrinth. You can use this to refer to other projects on Modrinth or specify a json file path.
 # Syntax: scope1-type1:name1;scope2-type2:name2;...
 # Where scope can be one of [required, optional, incompatible, embedded],
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:jei;optional-project:top;incompatible-project:gregtech
-modrinthRelations =
+modrinthRelations = relations.json
 
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_API_KEY environment variable to one of your CurseForge API tokens.
@@ -118,12 +123,12 @@ modrinthRelations =
 # Alternatively this can be set with the 'CURSEFORGE_PROJECT_ID' environment variable.
 curseForgeProjectId =
 
-# The project's relations on CurseForge. You can use this to refer to other projects on CurseForge.
+# The project's relations on CurseForge. You can use this to refer to other projects on CurseForge or specify a json file path.
 # Syntax: type1:name1;type2:name2;...
 # Where type can be one of [requiredDependency, embeddedLibrary, optionalDependency, tool, incompatible],
 #       and the name is the CurseForge project slug of the other mod.
 # Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
-curseForgeRelations =
+curseForgeRelations = relations.json
 
 # This project's release type on CurseForge and/or Modrinth
 # Alternatively this can be set with the 'RELEASE_TYPE' environment variable.

--- a/src/main/java/com/myname/mymodid/MyMod.java
+++ b/src/main/java/com/myname/mymodid/MyMod.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = Tags.MODID, version = Tags.VERSION, name = Tags.MODNAME, acceptedMinecraftVersions = "[1.12.2]")
+@Mod(modid = Tags.MODID, version = Tags.VERSION, name = Tags.MODNAME, dependencies = Tags.DEPENDENCIES, acceptedMinecraftVersions = "[1.12.2]")
 public class MyMod {
 
     public static final Logger LOGGER = LogManager.getLogger(Tags.MODID);


### PR DESCRIPTION
The curse and modrinth dependencies can get very messy when you have more than 3 dependencies (which is the case for groovyscript and bogosorter).
This makes it so dependencies can be parsed from one file and converted to Curse, Modrinth and even Forge dependencies.
The Forge dependency string (in the mod annotation) can be injected via tags like this.
The old way is still possible.
I also added a doc page as the syntax it can be very confusing.