### PR TITLE
Shorter Dependency types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -906,6 +906,12 @@ if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
                     }
                     String[] parts = dep.split(':')
                     String type = parts[0], slug = parts[1]
+                    def types = [
+                            'req'   : 'requiredDependency', 'required': 'requiredDependency',
+                            'opt'   : 'optionalDependency', 'optional': 'optionalDependency',
+                            'embed' : 'embeddedLibrary',    'embedded': 'embeddedLibrary',
+                            'incomp': 'incompatible',       'fail'    : 'incompatible']
+                    if (types.containsKey(type)) type = types[type]
                     if (!(type in ['requiredDependency', 'embeddedLibrary', 'optionalDependency', 'tool', 'incompatible'])) {
                         throw new Exception('Invalid Curseforge dependency type: ' + type)
                     }
@@ -948,7 +954,7 @@ if (modrinthApiKey.isPresent() || deploymentDebug.toBoolean()) {
             }
             String[] parts = dep.split(':')
             String[] qual = parts[0].split('-')
-            addModrinthDep(qual[0], qual[1], parts[1])
+            addModrinthDep(qual[0], qual.length > 1 ? qual[1] : 'project', parts[1])
         }
     }
     tasks.modrinth.dependsOn(build)
@@ -957,9 +963,17 @@ if (modrinthApiKey.isPresent() || deploymentDebug.toBoolean()) {
 
 def addModrinthDep(String scope, String type, String name) {
     com.modrinth.minotaur.dependencies.Dependency dep
+    def types = [
+            'req'   : 'required',
+            'opt'   : 'optional',
+            'embed' : 'embedded',
+            'incomp': 'incompatible', 'fail': 'incompatible']
+    if (types.containsKey(scope)) scope = types[scope]
     if (!(scope in ['required', 'optional', 'incompatible', 'embedded'])) {
         throw new Exception('Invalid modrinth dependency scope: ' + scope)
     }
+    types = ['proj': 'project', '': 'project', 'p': 'project', 'ver': 'version', 'v': 'version']
+    if (types.containsKey(type)) type = types[type]
     switch (type) {
         case 'project':
             dep = new ModDependency(name, scope)


### PR DESCRIPTION
Curse requires very long dependency types like `requiredDependency`. This PR allows it to be shortened to `required` or just `req`.
Now you can use the same types for modrinth and curse. 

- required: `req`, `required`, (curse: `requiredDependency`)
- optional: `opt`, `optional`, (curse: `optionalDependency`)
- embedded: `embed`, `embedded`, (curse: 'embeddedLibrary')
- incompatible: `fail`, `incomp`, `incompatible`

Also modrinth requires `-version` or `-project`. This pr allows it to be shortened to `-proj` or `-ver` or just `-p` or `-v`. You can also omit it and it defaults to `-project`.
