### PR TITLE
move to the HTTPS GTNH maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,8 +436,7 @@ repositories {
         }
         maven {
             name 'GTNH Maven'
-            url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public'
-            allowInsecureProtocol = true
+            url 'https://nexus.gtnewhorizons.com/repository/public/'
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,9 +3,7 @@ pluginManagement {
         maven {
             // RetroFuturaGradle
             name 'GTNH Maven'
-            //noinspection HttpUrlsUsage
-            url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'
-            allowInsecureProtocol = true
+            url 'https://nexus.gtnewhorizons.com/repository/public/'
             //noinspection GroovyAssignabilityCheck
             mavenContent {
                 includeGroup 'com.gtnewhorizons'


### PR DESCRIPTION
Moves GTNH maven urls to the new HTTPS endpoint.