### PR TITLE
Set insecure deps behind a property option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ propertyDefaultIfUnset("gradleTokenVersion", "")
 propertyDefaultIfUnset("useSrcApiPath", false)
 propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
+propertyDefaultIfUnset("allowInsecureDependencySources", false)
 propertyDefaultIfUnset("noPublishedSources", false)
 propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnsetWithEnvVar("enableCoreModDebug", false, "CORE_MOD_DEBUG")
@@ -392,7 +393,7 @@ tasks.named('processIdeaSettings').configure {
 
 // Allow unsafe repos but warn
 repositories.configureEach { repo ->
-    if (repo instanceof UrlArtifactRepository) {
+    if (allowInsecureDependencySources.toBoolean() && repo instanceof UrlArtifactRepository) {
         if (repo.getUrl() != null && repo.getUrl().getScheme() == "http" && !repo.allowInsecureProtocol) {
             logger.warn("Deprecated: Allowing insecure connections for repo '${repo.name}' - add 'allowInsecureProtocol = true'")
             repo.allowInsecureProtocol = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -80,6 +80,9 @@ includeWellKnownRepositories = true
 # Overrides the above setting to be always true, as these repositories are needed to fetch the mods
 includeCommonDevEnvMods = true
 
+# Allows fetching dependencies from sources deemed insecure, ie, may be over http
+# Will log the source repository when this is enabled
+allowInsecureDependencySources = false
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.


### PR DESCRIPTION
Sets the insecure dependency option behind a gradle.property option, since we can now run the buildscript as is without allowing this.