### PR TITLE
Fix unused useSrcApiPath problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ if (!getFile(targetPackageJava).exists() && !getFile(targetPackageScala).exists(
 
 if (apiPackage) {
     final String endApiPath = modGroupPath + '/' + apiPackagePath
-    if (useSrcApiPath) {
+    if (useSrcApiPath.toBoolean()) {
         targetPackageJava = 'src/api/java/' + endApiPath
         targetPackageScala = 'src/api/scala/' + endApiPath
         targetPackageKotlin = 'src/api/kotlin/' + endApiPath


### PR DESCRIPTION
Pull Request for #95 
## What did you do ?
https://github.com/GregTechCEu/Buildscripts/blob/97d9314818fabeb6b2ac34c158c45def4aafba02/build.gradle#L110
Replaced ```useSrcApiPath``` to ```useSrcApiPath.toBoolean()```