### PR TITLE
add additionalJavaArguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ propertyDefaultIfUnset("includeMCVersionJar", false)
 propertyDefaultIfUnset("autoUpdateBuildScript", false)
 propertyDefaultIfUnset("modArchivesBaseName", project.modId)
 propertyDefaultIfUnsetWithEnvVar("developmentEnvironmentUserName", "Developer", "DEV_USERNAME")
+propertyDefaultIfUnset("additionalJavaArguments", "")
 propertyDefaultIfUnset("generateGradleTokenClass", "")
 propertyDefaultIfUnset("gradleTokenModId", "")
 propertyDefaultIfUnset("gradleTokenModName", "")
@@ -368,6 +369,10 @@ minecraft {
                 '-Dlegacy.debugClassLoadingFiner=true',
                 '-Dlegacy.debugClassLoadingSave=true'
         ])
+    }
+
+    if (additionalJavaArguments.size() != 0) {
+        extraRunJvmArguments.addAll(additionalJavaArguments.split(';'))
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ minecraftVersion = 1.12.2
 developmentEnvironmentUserName = Developer
 
 # Additional arguments applied to the JVM when launching minecraft
-# Syntax: -arg1=value1;arg2=value2;...
+# Syntax: -arg1=value1;-arg2=value2;...
 # Example value: -Dmixin.debug.verify=true;-XX:+UnlockExperimentalVMOptions
 additionalJavaArguments = 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,11 @@ minecraftVersion = 1.12.2
 # Alternatively this can be set with the 'DEV_USERNAME' environment variable.
 developmentEnvironmentUserName = Developer
 
+# Additional arguments applied to the JVM when launching minecraft
+# Syntax: -arg1=value1;arg2=value2;...
+# Example value: -Dmixin.debug.verify=true;-XX:+UnlockExperimentalVMOptions
+additionalJavaArguments = 
+
 # Enables using modern java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
 # Using this requires that you use a Java 17 JDK for development.


### PR DESCRIPTION
for some projects, you will want to launch with additional java arguments. this may be to test performance, apply additional logging features, or some other reason.
this PR allows users to add additional java arguments via a new property for `gradle.properties`, `additionalJavaArguments`, and gives an example on the syntax.
