### PR TITLE
allow customizing mixinConfigRefmap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
 propertyDefaultIfUnset("noPublishedSources", false)
 propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("mixinConfigRefmap", "mixins.${project.modId}.refmap.json")
 propertyDefaultIfUnsetWithEnvVar("enableCoreModDebug", false, "CORE_MOD_DEBUG")
 propertyDefaultIfUnset("generateMixinConfig", true)
 propertyDefaultIfUnset("usesShadowedDependencies", false)
@@ -504,7 +505,7 @@ dependencies {
         // should use 2.8.6 but 2.8.9+ has a vulnerability fix
         annotationProcessor 'com.google.code.gson:gson:2.8.9'
 
-        mixinProviderSpec = modUtils.enableMixins(mixinProviderSpec, "mixins.${modId}.refmap.json")
+        mixinProviderSpec = modUtils.enableMixins(mixinProviderSpec, mixinConfigRefmap)
         api (mixinProviderSpec) {
             transitive = false
         }
@@ -679,7 +680,6 @@ tasks.register('generateAssets') {
         if (usesMixins.toBoolean() && generateMixinConfig.toBoolean()) {
             def mixinConfigFile = getFile("src/main/resources/mixins.${modId}.json")
             if (!mixinConfigFile.exists()) {
-                def mixinConfigRefmap = "mixins.${modId}.refmap.json"
 
                 mixinConfigFile.text = """{
   "package": "${modGroup}.${mixinsPackage}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,6 +55,8 @@ accessTransformersFile =
 usesMixins = false
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
 mixinsPackage =
+# Location of the mixin config refmap. If left, blank, defaults to "mixins.${modId}.refmap.json"
+mixinConfigRefmap =
 # Automatically generates a mixin config json if enabled, with the name mixins.modid.json
 generateMixinConfig = true
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ accessTransformersFile =
 usesMixins = false
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
 mixinsPackage =
-# Location of the mixin config refmap. If left, blank, defaults to "mixins.${modId}.refmap.json"
+# Location of the mixin config refmap. If left, blank, defaults to "mixins.${modId}.refmap.json". Target file must have the "json" extension.
 mixinConfigRefmap =
 # Automatically generates a mixin config json if enabled, with the name mixins.modid.json
 generateMixinConfig = true


### PR DESCRIPTION
changes in this PR:
- adds a new `gradle.properties` entry, `mixinConfigRefmap`, which defaults to an empty string.
- sets the new `mixinConfigRefmap` to `mixins.${project.modId}.refmap.json` if unset (doesnt exist or is an empty string)
- uses `mixinConfigRefmap` in the places where the refmap is targeted.

this allows users to have a custom refmap file instead of requiring it to be `mixins.${project.modId}.refmap.json`.
currently, if a user named this something that isnt a `json` file (for example, `silly.png`), the refmap file would still work correctly (this was tested, it injects mixins properly). however, due to my strong personal conviction that this should not be done, there is a verbal instruction that it must be a `json` file in the comment.
