### PR TITLE
add option to strip forge requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ propertyDefaultIfUnset("gradleTokenVersion", "")
 propertyDefaultIfUnset("useSrcApiPath", false)
 propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
+propertyDefaultIfUnset("stripForgeRequirements", false)
 propertyDefaultIfUnset("noPublishedSources", false)
 propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnsetWithEnvVar("enableCoreModDebug", false, "CORE_MOD_DEBUG")
@@ -560,6 +561,10 @@ dependencies {
     annotationProcessor 'org.jetbrains:annotations:24.1.0'
     patchedMinecraft('net.minecraft:launchwrapper:1.17.2') {
         transitive = false
+    }
+
+    if ((usesMixins.toBoolean() || forceEnableMixins.toBoolean()) && stripForgeRequirements.toBoolean()) {
+        runtimeOnlyNonPublishable 'com.cleanroommc:strip-latest-forge-requirements:1.0'
     }
 
     if (includeCommonDevEnvMods.toBoolean()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -86,6 +86,12 @@ includeWellKnownRepositories = true
 # Overrides the above setting to be always true, as these repositories are needed to fetch the mods
 includeCommonDevEnvMods = true
 
+# Some mods require a specific forge version to launch in. When you need to use one of those mods as a dependency,
+# and cannot launch with the forge version required, enable this to strip the forge version requirements from that mod.
+# This will add 'strip-latest-forge-requirements' as 'runtimeOnly'.
+# Requires useMixins or forceEnableMixins to be true.
+stripForgeRequirements = false
+
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.

--- a/gradle.properties
+++ b/gradle.properties
@@ -88,8 +88,8 @@ includeCommonDevEnvMods = true
 
 # Some mods require a specific forge version to launch in. When you need to use one of those mods as a dependency,
 # and cannot launch with the forge version required, enable this to strip the forge version requirements from that mod.
-# This will add 'strip-latest-forge-requirements' as 'runtimeOnly'.
-# Requires useMixins or forceEnableMixins to be true.
+# This will add 'strip-latest-forge-requirements' as 'runtimeOnlyNonPublishable'.
+# Requires useMixins or forceEnableMixins to be true, as the mod uses mixins to function.
 stripForgeRequirements = false
 
 


### PR DESCRIPTION
changes in this PR:
- adds a new `gradle.properties` entry, `stripForgeRequirements`, which defaults to `false`.
- sets the new `stripForgeRequirements` to `false` if unset.
- adds `com.cleanroommc:strip-latest-forge-requirements:1.0` via `runtimeOnlyNonPublishable` if `stripForgeRequirements` is true and mixins are enabled (either forcefully or standard).

this is done so that when you need to add dependencies which require at least a specific forge version, you dont have to manually add this mod, and its just a config change away.

if it didnt require mixins to be enabled i would want it set to `true` by default, but since it does in fact require mixins, that would cause it to be a weird side-effect of enabling mixins. as such, its a separate setting with a comment indicating it needs mixins to be enabled.