### PR TITLE
add gradle's wrapper validation workflow

### DIFF
--- a/.github/workflows/validate_gradle_wrapper.yml
+++ b/.github/workflows/validate_gradle_wrapper.yml
@@ -1,0 +1,29 @@
+# Validates the integrity of the Gradle Wrapper
+name: Validate Gradle Wrapper
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'gradle/**'
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'gradle/**'
+
+concurrency:
+  group: gradle-wrapper-validation-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation


### PR DESCRIPTION
Adds Gradle's validation workflow to report malicious changes to `gradlew` and related files.

This repository in particular is a larger target for supply chain attacks as many other projects rely on it, so validating the integrity of the Gradle tooling is important to do here.
