### PR TITLE
enable JLine Terminal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,6 +369,9 @@ minecraft {
 
     // JVM arguments
     extraRunJvmArguments.add("-ea:${modGroup}")
+
+    // enable JLine Terminal since idea_rt.jar is no longer added to the classpath
+    extraRunJvmArguments.add('-Dterminal.jline=true')
     if (usesMixins.toBoolean()) {
         extraRunJvmArguments.addAll([
             '-Dmixin.hotSwap=true',


### PR DESCRIPTION
Enables the JLine Terminal. This allows for colored terminal output detection. 

Forge checks if the classpath contains `idea_rt.jar`, which to my knowledge no longer exists. It also declared in a comment that Eclipse did not support ANSI escape codes in its terminal, but versions from 2022 and newer actually do.

If detection within JLine fails, Forge still falls back to stdout.

This PR enables using the terminal via a system property provided by forge. The relevant code is within `TerminalConsoleAppender`.
