### PR TITLE
Update Dependencies, allow for newer Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,12 +33,12 @@ plugins {
     id 'base'
     id 'eclipse'
     id 'maven-publish'
-    id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.8'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.4.0'
-    id 'net.darkhax.curseforgegradle' version '1.1.24' apply false
+    id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.9'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.4.1'
+    id 'net.darkhax.curseforgegradle' version '1.1.25' apply false
     id 'com.modrinth.minotaur' version '2.8.7' apply false
-    id 'com.diffplug.spotless' version '6.13.0' apply false
-    id 'com.palantir.git-version' version '3.0.0' apply false
+    //id 'com.diffplug.spotless' version '6.13.0' apply false
+    id 'com.palantir.git-version' version '3.1.0' apply false
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
     id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,11 @@ if (enableSpotless.toBoolean()) {
             target 'src/*/kotlin/**/*.kt'
 
             toggleOffOn()
-            ktfmt('0.39')
+            if (useNewerKotlinVersion.toBoolean()) {
+                ktfmt('0.53')
+            } else {
+                ktfmt('0.44')
+            }
 
             trimTrailingWhitespace()
             indentWithSpaces(4)
@@ -475,7 +479,7 @@ repositories {
             url 'https://maven.gtceu.com'
         }
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean() || useNewerKotlinVersion.toBoolean()) {
         // need to add this here even if we did not above
         if (!includeWellKnownRepositories.toBoolean()) {
             maven {

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ plugins {
     //id 'com.diffplug.spotless' version '6.13.0' apply false
     id 'com.palantir.git-version' version '3.1.0' apply false
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
-    id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
-    id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
-    id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
+    //id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
+    //id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
+    //id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
     id 'de.undercouch.download' version '5.6.0' apply false
 }
 
@@ -101,6 +101,7 @@ propertyDefaultIfUnset("enableModernJavaSyntax", false)
 propertyDefaultIfUnset("enableSpotless", false)
 propertyDefaultIfUnset("enableJUnit", false)
 propertyDefaultIfUnsetWithEnvVar("deploymentDebug", false, "DEPLOYMENT_DEBUG")
+propertyDefaultIfUnset("useNewerKotlinVersion", false)
 
 
 // Project property assertions
@@ -518,7 +519,7 @@ configurations {
     testRuntimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
 }
 
-String mixinProviderSpec = 'zone.rong:mixinbooter:9.1'
+String mixinProviderSpec = 'zone.rong:mixinbooter:10.1'
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
@@ -540,8 +541,8 @@ dependencies {
     }
 
     if (enableJUnit.toBoolean()) {
-        testImplementation 'org.hamcrest:hamcrest:2.2'
-        testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+        testImplementation 'org.hamcrest:hamcrest:3.0'
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.11.3'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }
 
@@ -563,9 +564,13 @@ dependencies {
         testCompileOnly "me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0"
     }
 
-    compileOnlyApi 'org.jetbrains:annotations:24.1.0'
-    annotationProcessor 'org.jetbrains:annotations:24.1.0'
-    patchedMinecraft('net.minecraft:launchwrapper:1.17.2') {
+    if (useNewerKotlinVersion.toBoolean()) {
+        implementation 'io.github.chaosunity.forgelin:Forgelin-Continuous:2.0.21.0'
+    }
+
+    compileOnlyApi 'org.jetbrains:annotations:26.0.1'
+    annotationProcessor 'org.jetbrains:annotations:26.0.1'
+    patchedMinecraft('net.minecraft:launchwrapper:1.17.3') {
         transitive = false
     }
 
@@ -575,7 +580,7 @@ dependencies {
 
     if (includeCommonDevEnvMods.toBoolean()) {
         if (!(modId.equals('jei'))) {
-            implementation 'mezz.jei:jei_1.12.2:4.16.1.302'
+            implementation 'mezz.jei:jei_1.12.2:4.16.1.1013'
         }
         if (!(modId.equals('theoneprobe'))) {
             //noinspection DependencyNotationArgument

--- a/build.gradle
+++ b/build.gradle
@@ -574,7 +574,7 @@ dependencies {
 
     compileOnlyApi 'org.jetbrains:annotations:26.0.1'
     annotationProcessor 'org.jetbrains:annotations:26.0.1'
-    patchedMinecraft('net.minecraft:launchwrapper:1.17.3') {
+    patchedMinecraft('net.minecraft:launchwrapper:1.17.4') {
         transitive = false
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,11 @@ additionalJavaArguments =
 # Using this requires that you use a Java 17 JDK for development.
 enableModernJavaSyntax = true
 
+# Bundles newer Kotlin versions for use with your mod
+# This requires newer language provider mods, such as Forgelin-Continuous
+# See https://github.com/ChAoSUnItY/Forgelin-Continuous
+useNewerKotlinVersion = false
+
 # Enables runClient/runServer tasks for Java 17 and Java 21 using LWJGL3ify.
 # This is primarily used to test if your mod is compatible with platforms running
 # Minecraft 1.12.2 on modern versions of Java and LWJGL, and assist in fixing any problems with it.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,11 @@
 pluginManagement {
+    plugins {
+        if (enableModernJavaSyntax.toBoolean()) {
+            id 'com.diffplug.spotless' version '6.23.3'
+        } else {
+            id 'com.diffplug.spotless' version '6.13.0'
+        }
+    }
     repositories {
         maven {
             // RetroFuturaGradle

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,18 @@ pluginManagement {
         } else {
             id 'com.diffplug.spotless' version '6.13.0'
         }
+
+        if (useNewerKotlinVersion.toBoolean()) {
+            // Kotlin Library is bundled into Forgelin-Continuous
+            //id 'org.jetbrains.kotlin.jvm' version '2.0.21' apply false
+            id 'org.jetbrains.kotlin.kapt' version '2.0.21' apply false
+            id 'com.google.devtools.ksp' version '2.0.21-1.0.27' apply false
+
+        } else {
+            id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
+            id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
+            id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
+        }
     }
     repositories {
         maven {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,9 @@
 pluginManagement {
     plugins {
-        if (enableModernJavaSyntax.toBoolean()) {
-            id 'com.diffplug.spotless' version '6.23.3'
+        if (enableModernJavaSyntax.toBoolean() || enableJava17RunTasks.toBoolean()) {
+            id 'com.diffplug.spotless' version '6.23.3' apply false
         } else {
-            id 'com.diffplug.spotless' version '6.13.0'
+            id 'com.diffplug.spotless' version '6.13.0' apply false
         }
 
         if (useNewerKotlinVersion.toBoolean()) {


### PR DESCRIPTION
Updates various dependencies to their latest versions.

Attempts to fix an issue with groovyscript and older Spotless versions by using a newer spotless version if Jabel is enabled. Jabel needs to be enabled here because the current version of Spotless in then project (6.13.0) is the last version maintaining java 8 support, and I don't know if we wanted to force compiling with newer java, which we would need to do to use newer Spotless versions.

Enables the use of newer (2.0+) versions of Kotlin through the new language provider, https://github.com/ChAoSUnItY/Forgelin-Continuous. In case anyone uses Kotlin. The Kotlin library is actually bundled into this provider, so we do not have to specify it ourselves. This mod is hosted on the Cleanroom Maven, which we are already including in our dependencies.

I don't think there is a similar mod that enables newer Scala versions to be used, and I didn't really bother looking for one.