### PR TITLE
Use dedicated properties file for buildscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ a custom file separate from `gradle.properties` for ease of use.
 - Copy the [`build.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/build.gradle), [`dependencies.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/dependencies.gradle), and [`repositories.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/repositories.gradle) files from this zip to your project
 - Copy the [`settings.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/settings.gradle) file from this zip to your project and replace your current one
 - Copy the [`buildscript.properties`](https://github.com/GregTechCEu/Buildscripts/blob/master/buildscript.properties) file from this zip to your project
-- Configure `buildscript.properties` for your mod
-- Create the file `gradle.properties` for your mod and create any property settings for use in custom gradle files - primarily `dependencies.gradle`
+- Configure `buildscript.properties` to adjust the `build.gradle` settings to suit your project
+- Configure `gradle.properties` to create any property settings for use in other gradle files - primarily `dependencies.gradle`
 - Move the necessary `dependencies` and/or `repositories` from `build.gradle.old` to the respective files (`dependencies.gradle`, `repositories.gradle`)
     - NOTE that if you enable the `includeWellKnownRepositories` option in `buildscript.properties`, this build script will automatically have the following Maven locations, meaning you don't need to add them yourself in `repositories.gradle`:
       1. Curse Maven

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ This build script was heavily inspired by the build script created by GT New Hor
 - Automatic mod version detection from the latest git tag (or manually specified, if you prefer)
 - Updated Launchwrapper for better ASM/mixin debugging options
 
-And many more to come! And of course, all of these features are toggleable via an option in `gradle.properties`.
+And many more to come! And of course, all of these features are toggleable via an option in `buildscript.properties`,
+a custom file separate from `gradle.properties` for ease of use.
 
 ## How to Install (New Project)
 - Download the latest **starter.zip** release from [here](https://github.com/GregTechCEu/Buildscripts/releases) and extract into your project directory
 - Import into your IDE (we recommend IntelliJ IDEA, as it has the best support for modded Minecraft)
 - Choose a license for your code
 - Ensure your project is initialized in git. For example, you can run `git init; git commit --message "initial commit"`
-- Replace placeholder values, such as `gradle.properties`, package/class names for your `src/main` directory, etc.
+- Replace placeholder values, such as in `buildscript.properties`, package/class names for your `src/main` directory, etc.
 - Run `./gradlew setupDecompWorkspace`
 - Run `./gradlew updateBuildScript` to ensure that you are on the latest version
 - You are good to go! You can now run the `runClient` run configuration or run `./gradlew runClient` to launch the game
@@ -47,15 +48,16 @@ And many more to come! And of course, all of these features are toggleable via a
 - Rename your `build.gradle` file to `build.gradle.old`
 - Copy the [`build.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/build.gradle), [`dependencies.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/dependencies.gradle), and [`repositories.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/repositories.gradle) files from this zip to your project
 - Copy the [`settings.gradle`](https://github.com/GregTechCEu/Buildscripts/blob/master/settings.gradle) file from this zip to your project and replace your current one
-- Copy all the options from the [`gradle.properties`](https://github.com/GregTechCEu/Buildscripts/blob/master/gradle.properties) file to your `gradle.properties` (or copy entirely if you did not have one). You can leave your existing options if you know you need them, otherwise they can likely be removed
-- Configure `gradle.properties` for your mod
+- Copy the [`buildscript.properties`](https://github.com/GregTechCEu/Buildscripts/blob/master/buildscript.properties) file from this zip to your project
+- Configure `buildscript.properties` for your mod
+- Create the file `gradle.properties` for your mod and create any property settings for use in custom gradle files - primarily `dependencies.gradle`
 - Move the necessary `dependencies` and/or `repositories` from `build.gradle.old` to the respective files (`dependencies.gradle`, `repositories.gradle`)
-    - NOTE that if you enable the `includeWellKnownRepositories` option in `gradle.properties`, this build script will automatically have the following Maven locations, meaning you don't need to add them yourself in `repositories.gradle`:
+    - NOTE that if you enable the `includeWellKnownRepositories` option in `buildscript.properties`, this build script will automatically have the following Maven locations, meaning you don't need to add them yourself in `repositories.gradle`:
       1. Curse Maven
       2. Modrinth Maven
       3. BlameJared Maven
       4. CleanroomMC Maven
-    - NOTE that if you enable the `includeCommonDevEnvMods` option in `gradle.properties`, this build script will automatically have the following Mods, meaning you don't need to add them yourself in `dependencies.gradle`:
+    - NOTE that if you enable the `includeCommonDevEnvMods` option in `buildscript.properties`, this build script will automatically have the following Mods, meaning you don't need to add them yourself in `dependencies.gradle`:
       1. JEI
       2. The One Probe
 - Delete the `build.gradle.old` file
@@ -63,14 +65,15 @@ And many more to come! And of course, all of these features are toggleable via a
 
 ### Advanced
 - If your project was using Mixins, you may get a new mixin config file generated as `mixins.{modid}.json`, if yours was not named this way. Currently, you will have to move your Mixin config options to this newly generated file. If this behavior does not suit your needs, feel free to open an issue and start a discussion on different behavior
-- If your project was using environment variables for CI deployments, see the `gradle.properties` file's comments to view the environment variable names this script checks for
+- If your project was using environment variables for CI deployments, see the `buildscript.properties` file's comments to view the environment variable names this script checks for
 - If you have any additional build script code that you need to be applied, create an `addon.gradle` file and put it there
 - If your project has no dependencies, you can safely delete the `repositories.gradle` and `dependencies.gradle` files, they are optional
 
 ## How to Use
 ### Files
 - `build.gradle`: This file is automatically updated, and as a result should not be modified by the user directly
-- `gradle.properties`: Contains all the user configuration for the build script
+- `buildscript.properties`: Contains all the user configuration for the build script
+- `gradle.properties`: Contains all the user configuration for general gradle files
 - `settings.gradle`: This file contains some basic setup of the build script. It is currently not versioned, so it is safe to add to, though should not have things removed from it
 ### Custom Files
 Any of these files can optionally be either `.gradle` (Groovy), or `.gradle.kts` (Kotlin DSL).

--- a/build.gradle
+++ b/build.gradle
@@ -1491,7 +1491,9 @@ def loadProjectProperties() {
         configFile.withReader {
             def prop = new Properties()
             prop.load(it)
-            project.ext.config = new ConfigSlurper().parse(prop)
+            new ConfigSlurper().parse(prop).forEach { String k, def v ->
+                project.ext.setProperty(k, v)
+            }
         }
     } else {
         print("Failed to read from buildscript.properties, as it did not exist!")

--- a/build.gradle
+++ b/build.gradle
@@ -1477,7 +1477,7 @@ tasks.register('faq') {
                 "To add new dependencies to your project, place them in 'dependencies.gradle', NOT in 'build.gradle' as they would be replaced when the script updates.\n" +
                 "To add new repositories to your project, place them in 'repositories.gradle'.\n" +
                 "If you need additional gradle code to run, you can place it in a file named 'addon.gradle' (or either of the above, up to you for organization).\n\n" +
-                "If your build fails to recognize the syntax of newer Java versions, enable Jabel in your 'gradle.properties' under the option name 'enableModernJavaSyntax'.\n" +
+                "If your build fails to recognize the syntax of newer Java versions, enable Jabel in your 'buildscript.properties' under the option name 'enableModernJavaSyntax'.\n" +
                 "To see information on how to configure your IDE properly for Java 17, see https://github.com/GregTechCEu/Buildscripts/blob/master/docs/jabel.md\n\n" +
                 "Report any issues or feature requests you have for this build script to https://github.com/GregTechCEu/Buildscripts/issues\n")
     }
@@ -1509,7 +1509,7 @@ def getFile(String relativePath) {
 
 def checkPropertyExists(String propertyName) {
     if (!project.hasProperty(propertyName)) {
-        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GregTechCEu/Buildscripts/blob/main/gradle.properties")
+        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"buildscript.properties\" or \"gradle.properties\". You can find all properties and their description here: https://github.com/GregTechCEu/Buildscripts/blob/main/buildscript.properties and https://github.com/GregTechCEu/Buildscripts/blob/main/gradle.properties")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ def out = services.get(StyledTextOutputFactory).create('an-output')
 
 
 // Project properties
+loadProjectProperties()
+
 
 // Required properties: we don't know how to handle these being missing gracefully
 checkPropertyExists("modName")
@@ -1483,6 +1485,18 @@ tasks.register('faq') {
 
 
 // Helpers
+def loadProjectProperties() {
+    def configFile = file("buildscript.properties")
+    if (configFile.exists()) {
+        configFile.withReader {
+            def prop = new Properties()
+            prop.load(it)
+            project.ext.config = new ConfigSlurper().parse(prop)
+        }
+    } else {
+        print("Failed to read from buildscript.properties, as it did not exist!")
+    }
+}
 
 def getDefaultArtifactGroup() {
     def lastIndex = project.modGroup.lastIndexOf('.')

--- a/buildscript.properties
+++ b/buildscript.properties
@@ -190,11 +190,3 @@ enableJUnit = true
 # Uncomment this to test deployments to CurseForge and Modrinth
 # Alternatively, you can set the 'DEPLOYMENT_DEBUG' environment variable.
 deploymentDebug = false
-
-
-# Gradle Settings
-# Effectively applies the '--stacktrace' flag by default
-org.gradle.logging.stacktrace = all
-# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs = -Xmx3G

--- a/buildscript.properties
+++ b/buildscript.properties
@@ -30,7 +30,7 @@ developmentEnvironmentUserName = Developer
 # Additional arguments applied to the JVM when launching minecraft
 # Syntax: -arg1=value1;-arg2=value2;...
 # Example value: -Dmixin.debug.verify=true;-XX:+UnlockExperimentalVMOptions
-additionalJavaArguments = 
+additionalJavaArguments =
 
 # Enables using modern java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.

--- a/buildscript.properties
+++ b/buildscript.properties
@@ -1,8 +1,17 @@
+#
+# The "buildscript.properties" file contains settings loaded and used by the "build.gradle" file.
+# For settings loaded in all gradle files or custom settings, use "gradle.properties" instead.
+# New properties should not be created in this file, use "gradle.properties" instead.
+#
+
+# The name of your mod. Can be any sequence of characters.
 modName = MyMod
 
-# This is a case-sensitive string to identify your mod. Convention is to use lower case.
+# This is a case-sensitive string to identify your mod.
+# Must be less than 64 characters and all lowercase. Convention is to only contain alphabetic characters.
 modId = mymodid
 
+# Project package location.
 modGroup = com.myname.mymodid
 
 # Version of your mod.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,13 @@
+#
+# The "gradle.properties" file is used as a config file to control the default values of project properties.
+# For the "build.gradle" file, all properties are stored in the separate and dedicated file "buildscript.properties".
+# Properties can be created via any sequence of ASCII characters followed by an equal sign to set the value.
+#
+
+
+# Gradle Settings
+# Effectively applies the '--stacktrace' flag by default
+org.gradle.logging.stacktrace = all
+# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
+# This is required to provide enough memory for the Minecraft decompilation process.
+org.gradle.jvmargs = -Xmx3G

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# The "gradle.properties" file is used as a config file to control the default values of project properties.
+# The "gradle.properties" file contains settings loaded by all gradle files.
 # For the "build.gradle" file, all properties are stored in the separate and dedicated file "buildscript.properties".
 # Properties can be created via any sequence of ASCII characters followed by an equal sign to set the value.
 #


### PR DESCRIPTION
changes in this PR:
- create a new file, `buildscript.properties`, and move all `gradle.properties` only used in the `build.gradle` file into the new file.
	- load the options from this file in `build.gradle`.
	- the entries not moved are `org.gradle.logging.stacktrace` and `org.gradle.jvmargs`.
- add comments describing the files and how to use them.
	- also comment two entries missing a comment, `modName` and `modGroup`.
	- adjust the comment for the `modId`, as it incorrectly stated that the it was "convention" to be all lowercase instead of a requirement, see `FMLModContainer#sanityCheckModId` throwing `IllegalArgumentException`, preventing it a mod from being loaded in `ModContainerFactory#build`.
- adjust README.md and info/error messages that referenced the `gradle.properties` file to instead indicate the `buildscript.properties` file.

reasoning:
- separates out the custom properties that arent used anywhere other than `build.gradle` into their own dedicated file, ensuring they dont pollute the global configs.
- reduces possible confusion involving custom gradle properties (what settings are buildscript vs custom?) and associated clutter.
	- this is particularly relevant with GroovyScript, Universal Tweaks, and other mods like them.

potential concerns:
- migrations are not needed for this change:
	- if the `buildscript.properties` file isnt found, and single error will be noted, but loading will continue.
	- as the entries from `gradle.properties` are loaded in every file, them not being moved doesnt cause any issues.
	- furthermore, actually making a migration to do this is problematic - converting the existing `gradle.properties` file is non-viable due to breaking custom gradle properties.
- the "jump to source/uses" feature of intellij might not work properly. for me, it appears to only identify the source uses when they are inside a string.

PR review considerations:
- adding instructions for how to migrate in order to get the benefit of this might be worthwhile.
- it might be better to have a different name for `buildscript.properties`- ie `build.properties`.
- the readme likely needs improvement. 
