### PR TITLE
Exclude external ForgePatches dep if Mod is lwjgl3ify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -870,12 +870,11 @@ if (enableJava17RunTasks.toBoolean()) {
 
     dependencies {
         if (modId != 'lwjgl3ify') {
-            java17Dependencies("io.github.twilightflower:lwjgl3ify:1.0.0"
+            java17Dependencies("io.github.twilightflower:lwjgl3ify:1.0.0")
             java17PatchDependencies("io.github.twilightflower:lwjgl3ify:1.0.0:forgePatches") {
             transitive = false
+            }
         }
-        }
-
     }
 
     ext.java17JvmArgs = [

--- a/build.gradle
+++ b/build.gradle
@@ -870,11 +870,12 @@ if (enableJava17RunTasks.toBoolean()) {
 
     dependencies {
         if (modId != 'lwjgl3ify') {
-            java17Dependencies("io.github.twilightflower:lwjgl3ify:1.0.0")
-        }
-        java17PatchDependencies("io.github.twilightflower:lwjgl3ify:1.0.0:forgePatches") {
+            java17Dependencies("io.github.twilightflower:lwjgl3ify:1.0.0"
+            java17PatchDependencies("io.github.twilightflower:lwjgl3ify:1.0.0:forgePatches") {
             transitive = false
         }
+        }
+
     }
 
     ext.java17JvmArgs = [


### PR DESCRIPTION
ForgePatches get built inside LWJGL3ify, there is no reason to reinclude it as a dependency.