### PR TITLE
Update eclipse format to 4.37

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ if (enableSpotless.toBoolean()) {
             removeUnusedImports()
             endWithNewline()
             //noinspection GroovyAssignabilityCheck
-            eclipse('4.19.0').configFile(formatFile)
+            eclipse('4.37').configFile(formatFile)
         }
         kotlin {
             target 'src/*/kotlin/**/*.kt'


### PR DESCRIPTION
This provides proper formatting of modern java syntax, e.g.:
```diff
-entry instanceof ItemBlockMaterialPipe<?, ?>pipeItem
+entry instanceof ItemBlockMaterialPipe<?, ?> pipeItem
```