### PR TITLE
Bump RetroFuturaGradle plugin version to 1.4.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.8'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.4.0'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.4.1'
     id 'net.darkhax.curseforgegradle' version '1.1.24' apply false
     id 'com.modrinth.minotaur' version '2.8.7' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false


### PR DESCRIPTION
1.4.0 no longer exists on GTNH's Maven, causing builds to fail.

<img width="1253" height="495" alt="image" src="https://github.com/user-attachments/assets/39fac015-2538-4c7f-95d4-8bd0adf430dd" />
